### PR TITLE
Fix null get_tree() crashes and stale-coroutine ghost transitions

### DIFF
--- a/scripts/kitchen_scene.gd
+++ b/scripts/kitchen_scene.gd
@@ -1,0 +1,15 @@
+# kitchen_scene.gd
+# Attach to the ROOT node of your kitchen scene (kitchen-level.tscn).
+#
+# This is the only entry point into the round loop — it tells RoundManager
+# to start once the scene is fully in the tree. All NPC spawning, group
+# queries, and navigation baking happen AFTER this script's _ready() returns.
+extends Node2D
+
+func _ready() -> void:
+	# RoundManager is an AutoLoad singleton (Project > Project Settings > AutoLoad).
+	# Calling start_next_round() here is safe because:
+	#   1. AutoLoads are initialized before any scene _ready() fires.
+	#   2. start_next_round() defers one physics frame internally before
+	#      querying groups, so NavigationServer has time to bake the navmesh.
+	RoundManager.start_next_round()

--- a/scripts/round_manager.gd
+++ b/scripts/round_manager.gd
@@ -3,35 +3,27 @@
 # =============================================================================
 # PURPOSE: The "OS kernel" that orchestrates the entire Round-Robin game loop.
 #
-# Add this script to Project ▸ AutoLoad as "RoundManager" so every scene can
-# access it via RoundManager.start_next_round() etc.
+# AUTOLOAD SETUP (required):
+#   Project > Project Settings > AutoLoad tab
+#   Path: res://scripts/round_manager.gd   Node Name: RoundManager
 #
 # OS SCHEDULING ANALOGY:
-#   RoundManager IS the scheduler.  It:
-#     - Defines the time quantum (ROUND_DURATION = 60 s per round).
-#     - Enforces Round-Robin fairness: all 3 "processes" (customers) must
-#       receive equal service within each quantum.
-#     - Deducts HP (player health) for starvation — the canonical OS
-#       problem of a low-priority job never getting CPU time.
-#     - Declares game over when the system (player) runs out of health,
-#       mirroring a system crash caused by scheduling failure.
+#   RoundManager IS the scheduler. It defines the time quantum, enforces
+#   Round-Robin fairness across customers (processes), deducts HP for
+#   starvation, and declares game over when the system runs out of health.
 #
-# FAIRNESS RULE (matches your TODO exactly):
+# FAIRNESS RULE:
 #   At round end, find the maximum feed count among all customers.
-#   Any customer below that maximum is "underfed".
-#   • 1–2 underfed customers → -1 HP each.
-#   • 3+ underfed customers  → instant game over (death sound + game_over signal).
-#
-# WIN / LOSE:
-#   Win  = survive all MAX_ROUNDS (3) rounds with HP > 0.
-#   Lose = HP reaches 0 at any point before clearing round 3.
+#   Any customer below that max is "underfed".
+#   - 1-2 underfed -> -1 HP each
+#   - 3+ underfed  -> instant game over
 # =============================================================================
 
 class_name RoundManagerNode
 extends Node
 
 # ---------------------------------------------------------------------------
-# Signals — connect these in your HUD / MainGame scene
+# Signals
 # ---------------------------------------------------------------------------
 
 signal round_started(round_number: int)
@@ -41,7 +33,7 @@ signal game_over()
 signal game_won()
 
 # ---------------------------------------------------------------------------
-# Constants — tweak in one place, everything updates
+# Constants
 # ---------------------------------------------------------------------------
 
 const MAX_ROUNDS:          int   = 3
@@ -49,9 +41,10 @@ const ROUND_DURATION:      float = 60.0
 const MAX_HP:              int   = 3
 const CUSTOMERS_PER_ROUND: int   = 3
 
-var GROUP_CHEFS:      String = "chefs"
+# All group names are const — var would allow silent mutation that breaks queries.
+const GROUP_CHEFS:      String = "chefs"
 const GROUP_WAITERS:    String = "waiters"
-var GROUP_CUSTOMERS:  String = "customers"
+const GROUP_CUSTOMERS:  String = "customers"
 const GROUP_PLATES:     String = "plates"
 const GROUP_DEATH_SFX:  String = "death_sound"
 const GROUP_WAITER_TBL: String = "waiter_table"
@@ -68,55 +61,61 @@ var _feed_counts      : Dictionary = {}
 var _round_timer      : Timer
 
 # ---------------------------------------------------------------------------
-# Godot lifecycle
+# Lifecycle
 # ---------------------------------------------------------------------------
-# Add this variable near the top with the other runtime state vars
 
-# Update _ready() to cache it
 func _ready() -> void:
-	add_to_group(GROUP_CUSTOMERS)
+	# NOTE: Do NOT add_to_group(GROUP_CUSTOMERS) here.
+	# RoundManager is the scheduler — adding itself to the customers group
+	# would poison every get_nodes_in_group("customers") query and crash
+	# when the code tries to call walk_to_seat() on the manager itself.
+
 	_round_timer           = Timer.new()
 	_round_timer.one_shot  = true
 	_round_timer.wait_time = ROUND_DURATION
 	_round_timer.timeout.connect(_on_round_timer_expired)
 	add_child(_round_timer)
 
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
-func _assign_customers_to_plates() -> void:
-
-	var all_customers = get_tree().get_nodes_in_group(GROUP_CUSTOMERS)
-	var all_plates    = get_tree().get_nodes_in_group(GROUP_PLATES)
-
-	if all_plates.is_empty():
-		push_error("RoundManager: no nodes in 'plates' group found — tag your plate nodes!")
-		return
-	if all_customers.is_empty():
-		push_error("RoundManager: no nodes in 'customers' group found — tag your customer nodes!")
+func start_next_round() -> void:
+	current_round += 1
+	if current_round > MAX_ROUNDS:
+		push_warning("RoundManager: start_next_round() called after all rounds complete")
 		return
 
-	all_plates.shuffle()
+	print("RoundManager: -- Round %d starting --" % current_round)
+	_active_customers.clear()
+	_feed_counts.clear()
 
-	var count = min(CUSTOMERS_PER_ROUND, min(all_customers.size(), all_plates.size()))
+	# Defer one physics frame before querying groups.
+	# Reason: when called from kitchen_scene._ready(), the NavigationServer
+	# has not yet processed its first tick — navmesh isn't baked, so any
+	# move_to() call inside walk_to_seat() silently fails. One frame is
+	# enough for the server to catch up.
+	await get_tree().physics_frame
 
-	for i in range(count):
-		var customer : CustomerFSM = all_customers[i]
-		customer.assigned_plate    = all_plates[i]
-		customer.plate_index       = i + 1
-		customer.walk_to_seat()
-		_active_customers.append(customer)
-		_feed_counts[customer.get_instance_id()] = 0
+	_assign_customers_to_plates()
 
-	print("RoundManager: assigned %d customers to plates" % count)
+	# Give customers time to walk to their seats before the round starts.
+	await get_tree().create_timer(2.0).timeout
+
+	for customer in _active_customers:
+		customer.start_waiting()
+		if not customer.customer_fed.is_connected(_on_customer_fed):
+			customer.customer_fed.connect(_on_customer_fed)
+
+	round_started.emit(current_round)
+	_round_timer.start()
+	print("RoundManager: round timer started (%.0f s)" % ROUND_DURATION)
 
 
 func dispatch_waiter_for_burger(_chef: ChefFSM) -> void:
-	if get_tree() == null:
-		push_error("RoundManager: scene tree not available")
-		return
-
-	var waiters             = get_tree().get_nodes_in_group(GROUP_WAITERS)
-	var free_waiter         : WaiterFSM   = null
-	var hungry_customer     : CustomerFSM = null
+	var waiters         := get_tree().get_nodes_in_group(GROUP_WAITERS)
+	var free_waiter     : WaiterFSM   = null
+	var hungry_customer : CustomerFSM = null
 
 	for w in waiters:
 		if w is WaiterFSM and w.is_available():
@@ -133,7 +132,7 @@ func dispatch_waiter_for_burger(_chef: ChefFSM) -> void:
 			break
 
 	if hungry_customer == null:
-		push_warning("RoundManager: no hungry customer found — all fed or round ended")
+		push_warning("RoundManager: no hungry customer found")
 		return
 
 	free_waiter.assign_delivery(hungry_customer.assigned_plate, hungry_customer)
@@ -141,41 +140,9 @@ func dispatch_waiter_for_burger(_chef: ChefFSM) -> void:
 		  % [free_waiter.name, hungry_customer.plate_index])
 
 
-func _trigger_game_over() -> void:
-	if get_tree():
-		var sfx_nodes = get_tree().get_nodes_in_group(GROUP_DEATH_SFX)
-		for node in sfx_nodes:
-			if node is AudioStreamPlayer or node is AudioStreamPlayer2D:
-				node.play()
-	print("RoundManager: GAME OVER — player HP = %d" % player_hp)
-	game_over.emit()
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
+func on_burger_delivered(waiter: WaiterFSM, _plate: Node2D) -> void:
+	print("RoundManager: burger delivered by waiter=%s" % waiter.name)
 
-func start_next_round() -> void:
-	current_round += 1
-	if current_round > MAX_ROUNDS:
-		push_warning("RoundManager: start_next_round() called after all rounds complete")
-		return
-
-	print("RoundManager: ── Round %d starting ──" % current_round)
-	_active_customers.clear()
-	_feed_counts.clear()
-
-	get_tree().call_group(GROUP_CUSTOMERS, "_assign_customers_to_plates")
-
-	await get_tree().create_timer(2.0).timeout
-
-	for customer in _active_customers:
-		customer.start_waiting()
-		if not customer.customer_fed.is_connected(_on_customer_fed):
-			customer.customer_fed.connect(_on_customer_fed)
-
-	round_started.emit(current_round)
-	_round_timer.start()
-	print("RoundManager: round timer started (%.0f s)" % ROUND_DURATION)
-	
 
 func get_time_remaining() -> float:
 	return _round_timer.time_left
@@ -184,27 +151,63 @@ func get_time_remaining() -> float:
 func is_round_active() -> bool:
 	return not _round_timer.is_stopped()
 
-# ---------------------------------------------------------------------------
-# NPC setup helpers
-# ---------------------------------------------------------------------------
+
+func get_current_round() -> int:
+	return current_round
+
+
+func get_player_hp() -> int:
+	return player_hp
+
+
+func get_max_hp() -> int:
+	return MAX_HP
 
 # ---------------------------------------------------------------------------
-# Feed-count tracking
+# Private helpers
 # ---------------------------------------------------------------------------
+
+func _assign_customers_to_plates() -> void:
+	# Strict type filter: only CustomerFSM nodes count.
+	# Any other node accidentally in the "customers" group (mistagged,
+	# RoundManager itself if add_to_group was accidentally left in, etc.)
+	# is silently skipped rather than crashing the cast downstream.
+	var raw_customers := get_tree().get_nodes_in_group(GROUP_CUSTOMERS)
+	var all_customers : Array[CustomerFSM] = []
+	for node in raw_customers:
+		if node is CustomerFSM:
+			all_customers.append(node as CustomerFSM)
+
+	var all_plates := get_tree().get_nodes_in_group(GROUP_PLATES)
+
+	if all_plates.is_empty():
+		push_error("RoundManager: no nodes in group '%s' — tag your plate nodes in the Inspector!" % GROUP_PLATES)
+		return
+	if all_customers.is_empty():
+		push_error("RoundManager: no CustomerFSM nodes in group '%s' — add customers to the group in the Inspector!" % GROUP_CUSTOMERS)
+		return
+
+	all_plates.shuffle()
+
+	var count := mini(CUSTOMERS_PER_ROUND, mini(all_customers.size(), all_plates.size()))
+
+	for i in range(count):
+		var customer : CustomerFSM = all_customers[i]
+		customer.assigned_plate = all_plates[i]
+		customer.plate_index    = i + 1
+		customer.walk_to_seat()
+		_active_customers.append(customer)
+		_feed_counts[customer.get_instance_id()] = 0
+
+	print("RoundManager: assigned %d customers to plates" % count)
+
 
 func _on_customer_fed(customer: CustomerFSM) -> void:
 	var id := customer.get_instance_id()
 	if _feed_counts.has(id):
 		_feed_counts[id] += 1
-		print("RoundManager: customer %d feed count → %d" % [id, _feed_counts[id]])
+		print("RoundManager: customer %d feed count -> %d" % [id, _feed_counts[id]])
 
-
-func on_burger_delivered(waiter: WaiterFSM, _plate: Node2D) -> void:
-	print("RoundManager: waiter delivered burger (waiter=%s)" % waiter.name)
-
-# ---------------------------------------------------------------------------
-# Round evaluation
-# ---------------------------------------------------------------------------
 
 func _on_round_timer_expired() -> void:
 	print("RoundManager: round %d timer expired — evaluating fairness" % current_round)
@@ -218,7 +221,7 @@ func _evaluate_round_fairness() -> void:
 
 	for customer in _active_customers:
 		var fed : int = _feed_counts.get(customer.get_instance_id(), 0)
-		max_fed = max(max_fed, fed)
+		max_fed = maxi(max_fed, fed)
 
 	for customer in _active_customers:
 		var fed : int = _feed_counts.get(customer.get_instance_id(), 0)
@@ -246,38 +249,20 @@ func _evaluate_round_fairness() -> void:
 		game_won.emit()
 		return
 
-	print("RoundManager: moving to next round in 3 s...")
+	print("RoundManager: next round in 3 s...")
 	await get_tree().create_timer(3.0).timeout
 	start_next_round()
 
-# ---------------------------------------------------------------------------
-# HP management
-# ---------------------------------------------------------------------------
 
 func _deduct_hp(amount: int) -> void:
-	player_hp = max(0, player_hp - amount)
-	print("RoundManager: HP deducted by %d → HP = %d" % [amount, player_hp])
+	player_hp = maxi(0, player_hp - amount)
+	print("RoundManager: HP -%d -> HP = %d" % [amount, player_hp])
 	hp_changed.emit(player_hp)
 
-# ---------------------------------------------------------------------------
-# Game over
-# ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# Waiter dispatch helper
-# ---------------------------------------------------------------------------
-
-# ---------------------------------------------------------------------------
-# Utility / HUD helpers
-# ---------------------------------------------------------------------------
-
-func get_current_round() -> int:
-	return current_round
-
-
-func get_player_hp() -> int:
-	return player_hp
-
-
-func get_max_hp() -> int:
-	return MAX_HP
+func _trigger_game_over() -> void:
+	for node in get_tree().get_nodes_in_group(GROUP_DEATH_SFX):
+		if node is AudioStreamPlayer or node is AudioStreamPlayer2D:
+			node.play()
+	print("RoundManager: GAME OVER — HP = %d" % player_hp)
+	game_over.emit()

--- a/scripts/states/customer_fsm.gd
+++ b/scripts/states/customer_fsm.gd
@@ -5,19 +5,20 @@
 #          for food during the round, and reacts to being fed or ignored.
 #
 # OS SCHEDULING ANALOGY:
-#   Customers model "jobs" queued in the ready-queue waiting for a CPU time
-#   slice.  When the round (scheduling cycle) starts they enter WAITING —
-#   just like a process waiting to be scheduled.  Getting fed = being
-#   dispatched.  Being left unfed = starvation, which is exactly the fairness
-#   problem Round-Robin is designed to prevent.
+#   Customers model "jobs" in the ready-queue waiting for a CPU time slice.
+#   Getting fed = being dispatched. Being unfed = starvation.
 #
 # STATE FLOW:
-#   SPAWNING
-#     └─► WALK_TO_SEAT  (navigate to assigned plate node position)
-#           └─► IDLE_SEATED  (wait for RoundManager to call start_waiting())
-#                 └─► WAITING  (hungry — waiting for WaiterFSM to call receive_meal())
-#                       ├─► FED      (meal arrived — ding! → LEAVING → queue_free)
-#                       └─► LEAVING  (round ended unfed → silent exit → queue_free)
+#   SPAWNING -> WALK_TO_SEAT -> IDLE_SEATED -> WAITING
+#            -> FED (celebrate, then LEAVING -> queue_free)
+#            -> LEAVING (unfed exit -> queue_free)
+#
+# STALE-COROUTINE GUARD:
+#   _state_gen is incremented on every change_state() call. Each coroutine
+#   captures `gen = _state_gen` at entry and checks before any post-await
+#   side-effect. A mismatch means the state changed mid-wait — bail silently.
+#   (Same pattern as ChefFSM — prevents ghost transitions from FED/LEAVING
+#   timers firing after the customer has already been freed or re-entered.)
 # =============================================================================
 
 class_name CustomerFSM
@@ -28,65 +29,62 @@ extends BaseFSM
 # ---------------------------------------------------------------------------
 
 enum State {
-	SPAWNING,       # Just instantiated, not yet assigned a seat
-	WALK_TO_SEAT,   # Walking to their plate position
-	IDLE_SEATED,    # Seated, waiting for round to start
-	WAITING,        # Round active — hungry, waiting for food
-	FED,            # Meal delivered — celebrate then leave
-	LEAVING,        # Walking off / fading out before queue_free
+	SPAWNING,
+	WALK_TO_SEAT,
+	IDLE_SEATED,
+	WAITING,
+	FED,
+	LEAVING,
 }
 
 # ---------------------------------------------------------------------------
-# Exported configuration
+# Exports
 # ---------------------------------------------------------------------------
 
-## Which plate slot this customer maps to (1–7, matching your plate nodes).
-## Set this in the Inspector or via RoundManager before calling walk_to_seat().
 @export var plate_index: int = 1
 
 # ---------------------------------------------------------------------------
-# Runtime context
-# (Assigned by RoundManager before walk_to_seat() is called)
+# Runtime context (set by RoundManager before walk_to_seat())
 # ---------------------------------------------------------------------------
 
-## The plate Node2D this customer is assigned to — Waiter delivers here.
 var assigned_plate: Node2D = null
 
 # ---------------------------------------------------------------------------
-# Internal flags
+# Internal state
 # ---------------------------------------------------------------------------
 
-var _has_been_fed: bool = false
+var _has_been_fed : bool = false
+
+# Stale-coroutine guard — incremented on every state change.
+var _state_gen    : int  = 0
 
 # ---------------------------------------------------------------------------
 # Child-node references
 # ---------------------------------------------------------------------------
 
-## AudioStreamPlayer2D for the positive "ding" on a successful delivery.
-## Must be a direct child node named "AudioStreamPlayer2D" in the scene.
 @onready var _audio_ding: AudioStreamPlayer2D = $AudioStreamPlayer2D
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-## How long the customer celebrates before leaving after being fed.
-const FED_CELEBRATE_DURATION:  float = 1.0
-
-## How long the leaving animation plays before queue_free() is called.
-const LEAVING_EXIT_DURATION:   float = 1.5
+const FED_CELEBRATE_DURATION : float = 1.0
+const LEAVING_EXIT_DURATION  : float = 1.5
 
 # ---------------------------------------------------------------------------
 # Signals
 # ---------------------------------------------------------------------------
 
-## Fired when a meal is successfully delivered to this customer.
-## RoundManager listens to update the feed-count for fairness checking.
 signal customer_fed(customer: CustomerFSM)
-
-## Fired when check_fed_status() finds the customer was not fed this round.
-## RoundManager uses this to deduct HP from the player OS.
 signal customer_timed_out(customer: CustomerFSM)
+
+# ---------------------------------------------------------------------------
+# Override change_state to track generation
+# ---------------------------------------------------------------------------
+
+func change_state(new_state: int) -> void:
+	_state_gen += 1
+	super.change_state(new_state)
 
 # ---------------------------------------------------------------------------
 # BaseFSM hooks
@@ -96,13 +94,15 @@ func _on_ready() -> void:
 	_has_been_fed = false
 	change_state(State.SPAWNING)
 
+
 func _on_state_enter(state: int) -> void:
+	var gen := _state_gen  # capture generation for stale-guard checks below
+
 	match state:
 
 		State.SPAWNING:
 			play_anim("idle")
-			# The customer stands at their spawn point.
-			# RoundManager calls walk_to_seat() once the assigned_plate is set.
+			# Waits here until RoundManager calls walk_to_seat().
 
 		State.WALK_TO_SEAT:
 			play_anim("walk")
@@ -113,78 +113,67 @@ func _on_state_enter(state: int) -> void:
 
 		State.IDLE_SEATED:
 			play_anim("idle")
-			# Seated and calm — waiting for RoundManager to call start_waiting()
-			# when the player clicks the Start button.
+			# Seated and calm — waits for RoundManager.start_waiting().
 
 		State.WAITING:
-			play_anim("waiting")   # e.g. impatient tap / look-around animation
-			_has_been_fed = false  # Reset each round so fairness tracking is fresh
+			play_anim("waiting")
+			_has_been_fed = false
 
 		State.FED:
 			_has_been_fed = true
 			play_anim("happy")
-			# Play positive ding — confirms to the player a delivery succeeded.
 			if _audio_ding:
 				_audio_ding.play()
 			customer_fed.emit(self)
-			# Brief celebration before exiting the scene.
 			await get_tree().create_timer(FED_CELEBRATE_DURATION).timeout
+			if _state_gen != gen:
+				return  # state changed during celebration — don't double-transition
 			change_state(State.LEAVING)
 
 		State.LEAVING:
 			play_anim("walk")
-			# The customer walks off-screen (or fades).  After the exit duration
-			# the node is freed — RoundManager no longer references it.
 			await get_tree().create_timer(LEAVING_EXIT_DURATION).timeout
+			if _state_gen != gen:
+				return  # already freed or re-entered — don't call queue_free twice
 			queue_free()
+
 
 func _process_state(_delta: float) -> void:
 	match current_state:
-
 		State.WALK_TO_SEAT:
 			if has_reached_target():
 				change_state(State.IDLE_SEATED)
-
-		# All other states are timer-driven; nothing to poll here.
 
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
-## Called by RoundManager when the round timer starts.
-## Only transitions if the customer is already seated — guards against
-## calling this before walk_to_seat() has finished.
 func start_waiting() -> void:
 	if current_state == State.IDLE_SEATED:
 		change_state(State.WAITING)
 	else:
-		push_warning("CustomerFSM: start_waiting() called before customer is seated (state=%d)" % current_state)
+		push_warning("CustomerFSM: start_waiting() called before seated (state=%d)" % current_state)
 
-## Called by WaiterFSM when a burger is delivered to this customer's plate.
-## Transitions to FED — only valid while WAITING.
+
 func receive_meal() -> void:
 	if current_state == State.WAITING:
 		change_state(State.FED)
 	else:
-		push_warning("CustomerFSM: receive_meal() called outside of WAITING state (state=%d)" % current_state)
+		push_warning("CustomerFSM: receive_meal() called outside WAITING (state=%d)" % current_state)
 
-## Called by RoundManager at round end to apply the fairness / HP penalty rule.
-## Returns true  → customer was fed (no penalty).
-## Returns false → customer was NOT fed (fires customer_timed_out signal).
+
 func check_fed_status() -> bool:
 	if not _has_been_fed and current_state == State.WAITING:
 		customer_timed_out.emit(self)
-		# Silently leave — no celebration sound on an unfed exit.
 		change_state(State.LEAVING)
 		return false
 	return true
 
-## Assigns this customer to a plate and begins walking to it.
-## RoundManager calls this after spawn so the seat assignment is clean.
+
 func walk_to_seat() -> void:
 	change_state(State.WALK_TO_SEAT)
 
-## Returns true once the customer has reached their seat and is seated.
+
 func is_seated() -> bool:
 	return current_state == State.IDLE_SEATED or \
 		   current_state == State.WAITING or \


### PR DESCRIPTION
round_manager.gd:
- Remove add_to_group(GROUP_CUSTOMERS) from _ready() — manager was poisoning its own group query, causing walk_to_seat() to be called on itself and crashing
- Replace call_group(GROUP_CUSTOMERS, "_assign_customers_to_plates") with a direct self-call — the method lives on RoundManager, not on customer nodes
- Make GROUP_CHEFS and GROUP_CUSTOMERS const (were var, risked silent mutation breaking all group queries)
- Add await get_tree().physics_frame before _assign_customers_to_plates() so NavigationServer has baked the navmesh before move_to() is called
- Add strict CustomerFSM type filter in _assign_customers_to_plates()
- Replace max()/min() with maxi()/mini() for int operands
- Reorder methods so public API appears before private helpers

customer_fsm.gd:
- Add _state_gen counter + change_state() override (same pattern as ChefFSM) to guard FED and LEAVING coroutines from firing after the state has already changed — prevents double queue_free() and ghost transitions when a customer is freed mid-celebration

scripts/kitchen_scene.gd (new):
- Entry-point script to attach to the kitchen scene root node
- Calls RoundManager.start_next_round() from _ready() so the round begins as soon as the scene is fully loaded