### PR TITLE
Restructure os_menu.tscn to match script node references

### DIFF
--- a/os_menu.tscn
+++ b/os_menu.tscn
@@ -4,6 +4,9 @@
 
 [sub_resource type="Theme" id="Theme_2g2i4"]
 
+; ─────────────────────────────────────────────────────────────────────────────
+; ROOT — full-rect Control, script attached
+; ─────────────────────────────────────────────────────────────────────────────
 [node name="OSMenuScreen" type="Control" unique_id=183325884]
 layout_mode = 3
 anchors_preset = 15
@@ -13,6 +16,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_2g2i4")
 
+; Dark background that fills the whole viewport
 [node name="Background" type="ColorRect" parent="." unique_id=1666489746]
 layout_mode = 1
 anchors_preset = 15
@@ -22,6 +26,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.039, 0.047, 0.059, 1)
 
+; Center the OSWindow in the viewport
 [node name="CenterContainer" type="CenterContainer" parent="." unique_id=159040360]
 layout_mode = 1
 anchors_preset = 15
@@ -30,6 +35,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
+; ─────────────────────────────────────────────────────────────────────────────
+; OS WINDOW  (PanelContainer styled in code via _apply_theme)
+; ─────────────────────────────────────────────────────────────────────────────
 [node name="OSWindow" type="PanelContainer" parent="CenterContainer" unique_id=2102271661]
 custom_minimum_size = Vector2(760, 0)
 layout_mode = 2
@@ -39,388 +47,178 @@ theme = SubResource("Theme_2g2i4")
 layout_mode = 2
 theme_override_constants/separation = 0
 
+; ─────────────────────────────────────────────────────────────────────────────
+; TITLE BAR  — "KITCHEN OS · ROUND 01 · HP: 3/3 · SCORE: 0"
+; ─────────────────────────────────────────────────────────────────────────────
 [node name="TitleBar" type="PanelContainer" parent="CenterContainer/OSWindow/OSVBox" unique_id=533858801]
 custom_minimum_size = Vector2(0, 44)
 layout_mode = 2
 
 [node name="TitleHBox" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/TitleBar" unique_id=93815106]
 layout_mode = 2
-theme_override_constants/separation = 8
-
-[node name="DotsHBox" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/TitleBar/TitleHBox" unique_id=1101002572]
-layout_mode = 2
-size_flags_vertical = 4
-theme_override_constants/separation = 6
+theme_override_constants/separation = 12
 
 [node name="TitleLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/TitleBar/TitleHBox" unique_id=1552858754]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-text = "OS MENU"
-horizontal_alignment = 1
+text = "KITCHEN OS"
+horizontal_alignment = 0
 
 [node name="RoundLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/TitleBar/TitleHBox" unique_id=55581912]
 unique_name_in_owner = true
 layout_mode = 2
 text = "ROUND 01"
 
+[node name="HPLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/TitleBar/TitleHBox" unique_id=300000001]
+unique_name_in_owner = true
+layout_mode = 2
+text = "HP: 3/3"
+
+[node name="ScoreLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/TitleBar/TitleHBox" unique_id=300000002]
+unique_name_in_owner = true
+layout_mode = 2
+text = "SCORE: 0"
+
 [node name="TitleSep" type="HSeparator" parent="CenterContainer/OSWindow/OSVBox" unique_id=1750518393]
 layout_mode = 2
 
+; ─────────────────────────────────────────────────────────────────────────────
+; BODY ROW  — three columns: CHEFS | separator | WAITERS | separator | (NPC STATUS built in code)
+; ─────────────────────────────────────────────────────────────────────────────
 [node name="BodyRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox" unique_id=48077577]
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/separation = 0
 
-[node name="StatsBox" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=494566098]
-custom_minimum_size = Vector2(185, 0)
+; ── Column 1: CHEFS ──────────────────────────────────────────────────────────
+[node name="ChefsPanel" type="PanelContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=300000003]
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-size_flags_horizontal = 0
-theme_override_constants/separation = 0
 
-[node name="StaminaRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox" unique_id=1096870303]
-custom_minimum_size = Vector2(0, 38)
+[node name="ChefsVBox" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel" unique_id=300000004]
 layout_mode = 2
-theme_override_constants/separation = 0
+theme_override_constants/separation = 10
 
-[node name="StaminaKey" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/StaminaRow" unique_id=1656278485]
+[node name="ChefsHeader" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox" unique_id=300000005]
 layout_mode = 2
-size_flags_horizontal = 3
-text = "STAMINA"
-
-[node name="StaminaVal" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/StaminaRow" unique_id=589187175]
-unique_name_in_owner = true
-layout_mode = 2
-text = "100"
-horizontal_alignment = 2
-
-[node name="WaitersRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox" unique_id=86666174]
-custom_minimum_size = Vector2(0, 38)
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="WaitersKey" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/WaitersRow" unique_id=486677027]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "WAITERS"
-
-[node name="WaitersVal" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/WaitersRow" unique_id=2102409286]
-unique_name_in_owner = true
-layout_mode = 2
-text = "7"
-horizontal_alignment = 2
-
-[node name="ChefsRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox" unique_id=535703267]
-custom_minimum_size = Vector2(0, 38)
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="ChefsKey" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/ChefsRow" unique_id=352926745]
-layout_mode = 2
-size_flags_horizontal = 3
 text = "CHEFS"
+horizontal_alignment = 1
 
-[node name="ChefsVal" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/ChefsRow" unique_id=1707212810]
-unique_name_in_owner = true
+[node name="ChefsSep" type="HSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox" unique_id=300000006]
 layout_mode = 2
-text = "7"
-horizontal_alignment = 2
 
-[node name="UnservicedRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox" unique_id=920576710]
-custom_minimum_size = Vector2(0, 38)
+[node name="CookRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox" unique_id=300000007]
 layout_mode = 2
-theme_override_constants/separation = 0
+theme_override_constants/separation = 6
 
-[node name="UnservicedKey" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/UnservicedRow" unique_id=1823021167]
+[node name="CookLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox/CookRow" unique_id=300000008]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "NOT SERVICED"
+text = "Cook"
 
-[node name="UnservicedVal" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/StatsBox/UnservicedRow" unique_id=112420413]
+[node name="CookSpin" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox/CookRow" unique_id=300000009]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(72, 0)
 layout_mode = 2
-text = "0"
-horizontal_alignment = 2
+max_value = 7.0
 
+[node name="PrepRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox" unique_id=300000010]
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="PrepLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox/PrepRow" unique_id=300000011]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Prep"
+
+[node name="PrepSpin" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/ChefsPanel/ChefsVBox/PrepRow" unique_id=300000012]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(72, 0)
+layout_mode = 2
+max_value = 7.0
+
+; ── Separator 1 ──────────────────────────────────────────────────────────────
 [node name="VSep1" type="VSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=217401735]
 layout_mode = 2
 
-[node name="FIFOPanel" type="PanelContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=1132762233]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="FIFOVBox" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel" unique_id=775582460]
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="FIFOHeader" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox" unique_id=1463005072]
-custom_minimum_size = Vector2(0, 38)
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="FIFOName" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOHeader" unique_id=1914804117]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "FIFO"
-
-[node name="FIFOBadge" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOHeader" unique_id=1568181577]
-layout_mode = 2
-text = "-5 STA"
-
-[node name="FIFOSep" type="HSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox" unique_id=123709678]
+; ── Column 2: WAITERS ────────────────────────────────────────────────────────
+[node name="WaitersPanel" type="PanelContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=300000013]
+custom_minimum_size = Vector2(220, 0)
 layout_mode = 2
 
-[node name="FIFOInputs" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox" unique_id=1686540914]
+[node name="WaitersVBox" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel" unique_id=300000014]
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="FIFOWaitersRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs" unique_id=170427181]
+[node name="WaitersHeader" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox" unique_id=300000015]
 layout_mode = 2
-theme_override_constants/separation = 6
-
-[node name="FIFOWaitersLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs/FIFOWaitersRow" unique_id=1260781569]
-layout_mode = 2
-size_flags_horizontal = 3
 text = "WAITERS"
+horizontal_alignment = 1
 
-[node name="FIFOWaiters" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs/FIFOWaitersRow" unique_id=702257584]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(72, 0)
+[node name="WaitersSep" type="HSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox" unique_id=300000016]
 layout_mode = 2
-max_value = 7.0
 
-[node name="FIFOChefPrep" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs" unique_id=430854838]
+[node name="Plate1Row" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox" unique_id=300000017]
 layout_mode = 2
 theme_override_constants/separation = 6
 
-[node name="FIFOChefsPrepLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs/FIFOChefPrep" unique_id=1670602336]
+[node name="Plate1Label" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox/Plate1Row" unique_id=300000018]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "CHEFS: Prep"
+text = "Plate 1"
 
-[node name="FIFOChefPrepNum" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs/FIFOChefPrep" unique_id=1109484402]
+[node name="Plate1Spin" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox/Plate1Row" unique_id=300000019]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(72, 0)
 layout_mode = 2
 max_value = 7.0
 
-[node name="FIFOChefCook" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs" unique_id=1419216746]
+[node name="Plate2Row" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox" unique_id=300000020]
 layout_mode = 2
+theme_override_constants/separation = 6
 
-[node name="FIFOChefsCookLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs/FIFOChefCook" unique_id=1295502965]
+[node name="Plate2Label" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox/Plate2Row" unique_id=300000021]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "CHEFS: Cook"
+text = "Plate 2"
 
-[node name="FIFOChefCookNum" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox/FIFOInputs/FIFOChefCook" unique_id=1479657381]
+[node name="Plate2Spin" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox/Plate2Row" unique_id=300000022]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(72, 0)
 layout_mode = 2
 max_value = 7.0
 
-[node name="FIFOCostLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/FIFOPanel/FIFOVBox" unique_id=950256643]
+[node name="Plate3Row" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox" unique_id=300000023]
 layout_mode = 2
-text = "Arrival order  |  non-preemptive"
-horizontal_alignment = 1
-vertical_alignment = 2
+theme_override_constants/separation = 6
 
+[node name="Plate3Label" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox/Plate3Row" unique_id=300000024]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Plate 3"
+
+[node name="Plate3Spin" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/WaitersPanel/WaitersVBox/Plate3Row" unique_id=300000025]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(72, 0)
+layout_mode = 2
+max_value = 7.0
+
+; ── Separator 2  (script checks vsep2 by path before StatusPanel is built) ──
 [node name="VSep2" type="VSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=1702186122]
 layout_mode = 2
 
-[node name="SJFPanel" type="PanelContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=408983753]
-layout_mode = 2
-size_flags_horizontal = 3
+; Column 3 (NPC STATUS) is appended here at runtime by _build_status_queue_panel()
 
-[node name="SJFVBox" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel" unique_id=1673827465]
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="SJFHeader" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox" unique_id=1640114599]
-custom_minimum_size = Vector2(0, 38)
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="SJFName" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFHeader" unique_id=2062661660]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "SJF"
-
-[node name="SJFBadge" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFHeader" unique_id=242336965]
-layout_mode = 2
-text = "-15 STA"
-
-[node name="SJFSep" type="HSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox" unique_id=1814234056]
-layout_mode = 2
-
-[node name="SJFInputs" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox" unique_id=611345010]
-layout_mode = 2
-theme_override_constants/separation = 10
-
-[node name="SJFWaitersRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs" unique_id=1722950904]
-layout_mode = 2
-theme_override_constants/separation = 6
-
-[node name="SJFWaitersLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs/SJFWaitersRow" unique_id=1703934697]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "WAITERS"
-
-[node name="SJFWaiters" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs/SJFWaitersRow" unique_id=505731738]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(72, 0)
-layout_mode = 2
-max_value = 7.0
-
-[node name="SJFChefPrep" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs" unique_id=341378438]
-layout_mode = 2
-theme_override_constants/separation = 6
-
-[node name="SJFChefsPrepLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs/SJFChefPrep" unique_id=2124172543]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "CHEFS: Prep"
-
-[node name="SJFChefPrepNum" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs/SJFChefPrep" unique_id=119244597]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(72, 0)
-layout_mode = 2
-max_value = 7.0
-
-[node name="SJFChefCook" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs" unique_id=2080277242]
-layout_mode = 2
-
-[node name="SJFChefsCookLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs/SJFChefCook" unique_id=46232440]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "CHEFS: Cook"
-
-[node name="SJFChefCookNum" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox/SJFInputs/SJFChefCook" unique_id=153351829]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(72, 0)
-layout_mode = 2
-max_value = 7.0
-
-[node name="SJFCostLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJFPanel/SJFVBox" unique_id=1902904905]
-layout_mode = 2
-text = "Closest plate  |  commits on assign"
-horizontal_alignment = 1
-
-[node name="VSep3" type="VSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=2036089762]
-layout_mode = 2
-
-[node name="SJCFPanel" type="PanelContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow" unique_id=2032980172]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="SJCFVBox" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel" unique_id=2016366931]
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="SJCFHeader" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox" unique_id=1488229137]
-custom_minimum_size = Vector2(0, 38)
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="SJCFName" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFHeader" unique_id=88003603]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "SJCF"
-
-[node name="SJCFBadge" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFHeader" unique_id=1027510190]
-layout_mode = 2
-text = "-25 STA"
-
-[node name="SJCFSep" type="HSeparator" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox" unique_id=1377407005]
-layout_mode = 2
-
-[node name="SJCFInputs" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox" unique_id=1230725398]
-layout_mode = 2
-theme_override_constants/separation = 10
-
-[node name="SJCFWaitersRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs" unique_id=2079946786]
-layout_mode = 2
-theme_override_constants/separation = 6
-
-[node name="SJCFWaitersLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs/SJCFWaitersRow" unique_id=1965775447]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "WAITERS"
-
-[node name="SJCFWaiters" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs/SJCFWaitersRow" unique_id=397001331]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(72, 0)
-layout_mode = 2
-max_value = 7.0
-
-[node name="SJCFChefPrep" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs" unique_id=1042955968]
-layout_mode = 2
-theme_override_constants/separation = 6
-
-[node name="SJCFChefsPrepLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs/SJCFChefPrep" unique_id=681663513]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "CHEFS: Prep"
-
-[node name="SJCFChefPrepNum" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs/SJCFChefPrep" unique_id=1347800032]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(72, 0)
-layout_mode = 2
-max_value = 7.0
-
-[node name="SJCFChefCook" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs" unique_id=1221427801]
-layout_mode = 2
-
-[node name="SJCFChefsCookLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs/SJCFChefCook" unique_id=1196815490]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "CHEFS: Cook"
-
-[node name="SJCFChefCookNum" type="SpinBox" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox/SJCFInputs/SJCFChefCook" unique_id=1658759695]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(72, 0)
-layout_mode = 2
-max_value = 7.0
-
-[node name="SJCFCostLabel" type="Label" parent="CenterContainer/OSWindow/OSVBox/BodyRow/SJCFPanel/SJCFVBox" unique_id=2062529298]
-layout_mode = 2
-text = "Re-routes mid-delivery  |  preemptive"
-horizontal_alignment = 1
-
+; ─────────────────────────────────────────────────────────────────────────────
+; FOOTER
+; ─────────────────────────────────────────────────────────────────────────────
 [node name="FooterSep" type="HSeparator" parent="CenterContainer/OSWindow/OSVBox" unique_id=1693381651]
 layout_mode = 2
 
-[node name="FooterRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox" unique_id=2018093288]
+[node name="StartRoundBtn" type="Button" parent="CenterContainer/OSWindow/OSVBox" unique_id=883189492]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 52)
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="ServicedBox" type="VBoxContainer" parent="CenterContainer/OSWindow/OSVBox/FooterRow" unique_id=1852136419]
-custom_minimum_size = Vector2(185, 0)
-layout_mode = 2
-size_flags_horizontal = 0
-theme_override_constants/separation = 0
-
-[node name="ServicedRow" type="HBoxContainer" parent="CenterContainer/OSWindow/OSVBox/FooterRow/ServicedBox" unique_id=180688538]
-layout_mode = 2
-size_flags_vertical = 4
-theme_override_constants/separation = 0
-
-[node name="ServicedKey" type="Label" parent="CenterContainer/OSWindow/OSVBox/FooterRow/ServicedBox/ServicedRow" unique_id=820906124]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "SERVICED"
-
-[node name="ServicedVal" type="Label" parent="CenterContainer/OSWindow/OSVBox/FooterRow/ServicedBox/ServicedRow" unique_id=246354731]
-unique_name_in_owner = true
-layout_mode = 2
-text = "0"
-horizontal_alignment = 2
-
-[node name="FooterVSep" type="VSeparator" parent="CenterContainer/OSWindow/OSVBox/FooterRow" unique_id=279241754]
-layout_mode = 2
-
-[node name="StartRoundBtn" type="Button" parent="CenterContainer/OSWindow/OSVBox/FooterRow" unique_id=883189492]
-unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4

--- a/scripts/os-menu-script/os_menu.gd
+++ b/scripts/os-menu-script/os_menu.gd
@@ -4,20 +4,26 @@
 # =============================================================================
 # PURPOSE: Player allocation UI for each round.
 #
-# LAYOUT (two columns, matching the old FIFO/SJF/SJCF structure):
+# LAYOUT (three columns):
 #
-#   ┌─────────────────────────────────────────────┐
-#   │  KITCHEN OS  ·  ROUND 01  ·  ♥♥♥  SCORE: 0 │
-#   ├──────────────────┬──────────────────────────┤
-#   │     CHEFS        │        WAITERS            │
-#   │  Cook   [ 0 ↕ ]  │  Plate 1  [ 0 ↕ ]        │
-#   │  Prep   [ 0 ↕ ]  │  Plate 2  [ 0 ↕ ]        │
-#   │                  │  Plate 3  [ 0 ↕ ]        │
-#   ├──────────────────┴──────────────────────────┤
-#   │              [ START ROUND ]                 │
-#   └─────────────────────────────────────────────┘
+#   ┌──────────────────────────────────────────────────────────────┐
+#   │    KITCHEN OS  ·  ROUND 01  ·  HP: 3/3  ·  SCORE: 0        │
+#   ├──────────────┬──────────────────┬──────────────────────────  ┤
+#   │    CHEFS     │     WAITERS      │      NPC STATUS            │
+#   │ Cook  [0 ↕ ] │ Plate 1  [0 ↕ ] │ ── CHEFS ──               │
+#   │ Prep  [0 ↕ ] │ Plate 2  [0 ↕ ] │ Chef 1   Available         │
+#   │              │ Plate 3  [0 ↕ ] │ Chef 2   Available         │
+#   │              │                  │ Chef 3   Available         │
+#   │              │                  │ ── WAITERS ──              │
+#   │              │                  │ Waiter 1  Available        │
+#   │              │                  │ Waiter 2  Available        │
+#   │              │                  │ Waiter 3  Available        │
+#   ├──────────────┴──────────────────┴────────────────────────────┤
+#   │                      [ START ROUND ]                         │
+#   └──────────────────────────────────────────────────────────────┘
 #
-# SCENE SETUP (nodes you must create in os_menu.tscn — exact names matter):
+# SCENE SETUP — nodes required in os_menu.tscn (exact names matter):
+#
 #   Control (root)
 #   └─ CenterContainer
 #      └─ OSWindow (PanelContainer)
@@ -25,60 +31,71 @@
 #            ├─ TitleBar (PanelContainer)
 #            │  └─ TitleHBox (HBoxContainer)
 #            │     ├─ TitleLabel (Label)
-#            │     ├─ RoundLabel (Label) — unique name %RoundLabel
-#            │     ├─ HPLabel (Label)    — unique name %HPLabel
-#            │     └─ ScoreLabel (Label) — unique name %ScoreLabel
+#            │     ├─ RoundLabel (Label)  — check "Unique Name" → %RoundLabel
+#            │     ├─ HPLabel (Label)     — check "Unique Name" → %HPLabel
+#            │     └─ ScoreLabel (Label)  — check "Unique Name" → %ScoreLabel
 #            ├─ TitleSep (HSeparator)
-#            ├─ BodyRow (HBoxContainer)
+#            ├─ BodyRow (HBoxContainer)         ← the three columns live here
 #            │  ├─ ChefsPanel (PanelContainer)
 #            │  │  └─ ChefsVBox (VBoxContainer)
 #            │  │     ├─ ChefsHeader (Label)
 #            │  │     ├─ CookRow (HBoxContainer)
 #            │  │     │  ├─ CookLabel (Label)
-#            │  │     │  └─ CookSpin (SpinBox) — unique %CookSpin
+#            │  │     │  └─ CookSpin (SpinBox)   — unique %CookSpin
 #            │  │     └─ PrepRow (HBoxContainer)
 #            │  │        ├─ PrepLabel (Label)
-#            │  │        └─ PrepSpin (SpinBox) — unique %PrepSpin
+#            │  │        └─ PrepSpin (SpinBox)   — unique %PrepSpin
 #            │  ├─ VSep1 (VSeparator)
-#            │  └─ WaitersPanel (PanelContainer)
-#            │     └─ WaitersVBox (VBoxContainer)
-#            │        ├─ WaitersHeader (Label)
-#            │        ├─ Plate1Row (HBoxContainer)
-#            │        │  ├─ Plate1Label (Label)
-#            │        │  └─ Plate1Spin (SpinBox) — unique %Plate1Spin
-#            │        ├─ Plate2Row (HBoxContainer)
-#            │        │  ├─ Plate2Label (Label)
-#            │        │  └─ Plate2Spin (SpinBox) — unique %Plate2Spin
-#            │        └─ Plate3Row (HBoxContainer)
-#            │           ├─ Plate3Label (Label)
-#            │           └─ Plate3Spin (SpinBox) — unique %Plate3Spin
+#            │  ├─ WaitersPanel (PanelContainer)
+#            │  │  └─ WaitersVBox (VBoxContainer)
+#            │  │     ├─ WaitersHeader (Label)
+#            │  │     ├─ Plate1Row (HBoxContainer)
+#            │  │     │  ├─ Plate1Label (Label)
+#            │  │     │  └─ Plate1Spin (SpinBox) — unique %Plate1Spin
+#            │  │     ├─ Plate2Row (HBoxContainer)
+#            │  │     │  ├─ Plate2Label (Label)
+#            │  │     │  └─ Plate2Spin (SpinBox) — unique %Plate2Spin
+#            │  │     └─ Plate3Row (HBoxContainer)
+#            │  │        ├─ Plate3Label (Label)
+#            │  │        └─ Plate3Spin (SpinBox) — unique %Plate3Spin
+#            │  ├─ VSep2 (VSeparator)             ← NEW separator before status
+#            │  └─ StatusPanel (PanelContainer)   ← NPC STATUS QUEUE (built in code)
 #            ├─ FooterSep (HSeparator)
-#            └─ StartRoundBtn (Button) — unique %StartRoundBtn
+#            └─ StartRoundBtn (Button)             — unique %StartRoundBtn
+#
+# NOTE: StatusPanel is created and populated entirely in code — no child nodes
+# need to be added manually inside it in the editor.
 # =============================================================================
 
 extends Control
 
 # ---------------------------------------------------------------------------
-# Color palette (terminal dark theme)
+# Color palette
 # ---------------------------------------------------------------------------
 
-const C_BG      := Color("#0a0c0f")
-const C_PANEL   := Color("#0f1318")
-const C_BORDER  := Color("#1e3a2f")
-const C_ACCENT  := Color("#00ff88")
-const C_WARN    := Color("#ffb300")
-const C_DANGER  := Color("#ff4444")
-const C_TEXT    := Color("#c8ffd4")
-const C_MUTED   := Color("#4a7a5a")
-const C_HEADER  := Color("#071a10")
+const C_BG     := Color("#0a0c0f")
+const C_PANEL  := Color("#0f1318")
+const C_BORDER := Color("#1e3a2f")
+const C_ACCENT := Color("#00ff88")
+const C_WARN   := Color("#ffb300")
+const C_DANGER := Color("#ff4444")
+const C_TEXT   := Color("#c8ffd4")
+const C_MUTED  := Color("#4a7a5a")
+const C_HEADER := Color("#071a10")
+
+# Status color meanings:
+#   C_ACCENT = Available (idle, green)
+#   C_WARN   = Busy — Cooking or Prepping (amber)
+#   C_TEXT   = Busy — On Plate delivery (cream)
+#   C_MUTED  = Unknown / offline (dim)
 
 # ---------------------------------------------------------------------------
-# Node references (unique names — set up these nodes in the .tscn editor)
+# Allocation spinbox references (unique names — set in .tscn editor)
 # ---------------------------------------------------------------------------
 
-@onready var round_label : Label  = %RoundLabel
-@onready var hp_label    : Label  = %HPLabel
-@onready var score_label : Label  = %ScoreLabel
+@onready var round_label : Label   = %RoundLabel
+@onready var hp_label    : Label   = %HPLabel
+@onready var score_label : Label   = %ScoreLabel
 
 @onready var cook_spin   : SpinBox = %CookSpin
 @onready var prep_spin   : SpinBox = %PrepSpin
@@ -88,12 +105,24 @@ const C_HEADER  := Color("#071a10")
 
 @onready var start_btn   : Button  = %StartRoundBtn
 
-# Panel/separator style targets (full paths from root — adjust if hierarchy differs)
-@onready var os_window   : PanelContainer = $CenterContainer/OSWindow
-@onready var title_bar   : PanelContainer = $CenterContainer/OSWindow/OSVBox/TitleBar
-@onready var title_sep   : HSeparator     = $CenterContainer/OSWindow/OSVBox/TitleSep
-@onready var footer_sep  : HSeparator     = $CenterContainer/OSWindow/OSVBox/FooterSep
-@onready var vsep1       : VSeparator     = $CenterContainer/OSWindow/OSVBox/BodyRow/VSep1
+# Panel/separator nodes (full paths — adjust if your hierarchy differs)
+@onready var os_window  : PanelContainer = $CenterContainer/OSWindow
+@onready var title_bar  : PanelContainer = $CenterContainer/OSWindow/OSVBox/TitleBar
+@onready var title_sep  : HSeparator     = $CenterContainer/OSWindow/OSVBox/TitleSep
+@onready var footer_sep : HSeparator     = $CenterContainer/OSWindow/OSVBox/FooterSep
+@onready var vsep1      : VSeparator     = $CenterContainer/OSWindow/OSVBox/BodyRow/VSep1
+@onready var vsep2      : VSeparator     = $CenterContainer/OSWindow/OSVBox/BodyRow/VSep2
+@onready var body_row   : HBoxContainer  = $CenterContainer/OSWindow/OSVBox/BodyRow
+
+# ---------------------------------------------------------------------------
+# NPC Status Queue — built in code, updated after every round
+# ---------------------------------------------------------------------------
+
+## Ordered list of status Labels for Chef 1, 2, 3
+var _chef_status_labels   : Array[Label] = []
+
+## Ordered list of status Labels for Waiter 1, 2, 3
+var _waiter_status_labels : Array[Label] = []
 
 # ---------------------------------------------------------------------------
 # Lifecycle
@@ -102,8 +131,9 @@ const C_HEADER  := Color("#071a10")
 func _ready() -> void:
 	_apply_theme()
 	_connect_signals()
+	_build_status_queue_panel()   # constructs the third column in code
+	refresh_status_queue()        # show "Available" for all before first round
 	_refresh_display()
-
 
 # ---------------------------------------------------------------------------
 # Signal wiring
@@ -111,33 +141,217 @@ func _ready() -> void:
 
 func _connect_signals() -> void:
 	start_btn.pressed.connect(_on_start_round_pressed)
-
 	for spin in [cook_spin, prep_spin, plate1_spin, plate2_spin, plate3_spin]:
 		spin.value_changed.connect(_on_spin_changed)
+
+	# Auto-refresh status queue when RoundManager completes a round
+	if RoundManager.round_complete.is_connected(_on_round_complete) == false:
+		RoundManager.round_complete.connect(_on_round_complete)
 
 
 func _on_spin_changed(_v: float) -> void:
 	_refresh_display()
 
 
+func _on_round_complete(_round_num: int) -> void:
+	refresh_status_queue()
+
+
 func _on_start_round_pressed() -> void:
-	var cook  := int(cook_spin.value)
-	var prep  := int(prep_spin.value)
-	var p1    := int(plate1_spin.value)
-	var p2    := int(plate2_spin.value)
-	var p3    := int(plate3_spin.value)
+	var cook := int(cook_spin.value)
+	var prep := int(prep_spin.value)
+	var p1   := int(plate1_spin.value)
+	var p2   := int(plate2_spin.value)
+	var p3   := int(plate3_spin.value)
 
-	# Disable button so the player can't double-fire during NPC animation
 	start_btn.disabled = true
-
-	# Kick off the round — RoundManager is an AutoLoad singleton
 	await RoundManager.execute_round(cook, prep, p1, p2, p3)
 
-	# Round complete — reset spinboxes and re-enable for next allocation
 	_reset_spins()
+	refresh_status_queue()   # update statuses after the round finishes
 	_refresh_display()
 	start_btn.disabled = false
 
+# ---------------------------------------------------------------------------
+# NPC Status Queue — builder and refresher
+# ---------------------------------------------------------------------------
+
+## Builds the StatusPanel PanelContainer inside BodyRow entirely in code.
+## Called once from _ready(). No manual child nodes needed in the .tscn.
+func _build_status_queue_panel() -> void:
+	if body_row == null:
+		push_error("os_menu: body_row not found — check scene path 'BodyRow'")
+		return
+
+	# ── Outer panel ──────────────────────────────────────────────────────
+	var panel := PanelContainer.new()
+	panel.name = "StatusPanel"
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_style_panel(panel, C_PANEL, C_BORDER, 1, 0, 0)
+	body_row.add_child(panel)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 6)
+	panel.add_child(vbox)
+
+	# ── Header ───────────────────────────────────────────────────────────
+	var header_lbl := Label.new()
+	header_lbl.text = "NPC STATUS"
+	header_lbl.add_theme_color_override("font_color", C_ACCENT)
+	header_lbl.add_theme_font_size_override("font_size", 11)
+	vbox.add_child(header_lbl)
+
+	var sep := HSeparator.new()
+	_style_sep(sep)
+	vbox.add_child(sep)
+
+	# ── CHEFS section ────────────────────────────────────────────────────
+	var chef_section := Label.new()
+	chef_section.text = "── CHEFS ──"
+	chef_section.add_theme_color_override("font_color", C_MUTED)
+	chef_section.add_theme_font_size_override("font_size", 9)
+	vbox.add_child(chef_section)
+
+	_chef_status_labels.clear()
+	for i in range(3):
+		var row := HBoxContainer.new()
+		vbox.add_child(row)
+
+		var name_lbl := Label.new()
+		name_lbl.text = "Chef %d" % (i + 1)
+		name_lbl.custom_minimum_size = Vector2(60, 0)
+		name_lbl.add_theme_color_override("font_color", C_TEXT)
+		name_lbl.add_theme_font_size_override("font_size", 10)
+		row.add_child(name_lbl)
+
+		var status_lbl := Label.new()
+		status_lbl.text = "Available"
+		status_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		status_lbl.horizontal_alignment  = HORIZONTAL_ALIGNMENT_RIGHT
+		status_lbl.add_theme_color_override("font_color", C_ACCENT)
+		status_lbl.add_theme_font_size_override("font_size", 10)
+		row.add_child(status_lbl)
+		_chef_status_labels.append(status_lbl)
+
+	var sep2 := HSeparator.new()
+	_style_sep(sep2)
+	vbox.add_child(sep2)
+
+	# ── WAITERS section ──────────────────────────────────────────────────
+	var waiter_section := Label.new()
+	waiter_section.text = "── WAITERS ──"
+	waiter_section.add_theme_color_override("font_color", C_MUTED)
+	waiter_section.add_theme_font_size_override("font_size", 9)
+	vbox.add_child(waiter_section)
+
+	_waiter_status_labels.clear()
+	for i in range(3):
+		var row := HBoxContainer.new()
+		vbox.add_child(row)
+
+		var name_lbl := Label.new()
+		name_lbl.text = "Waiter %d" % (i + 1)
+		name_lbl.custom_minimum_size = Vector2(60, 0)
+		name_lbl.add_theme_color_override("font_color", C_TEXT)
+		name_lbl.add_theme_font_size_override("font_size", 10)
+		row.add_child(name_lbl)
+
+		var status_lbl := Label.new()
+		status_lbl.text = "Available"
+		status_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		status_lbl.horizontal_alignment  = HORIZONTAL_ALIGNMENT_RIGHT
+		status_lbl.add_theme_color_override("font_color", C_ACCENT)
+		status_lbl.add_theme_font_size_override("font_size", 10)
+		row.add_child(status_lbl)
+		_waiter_status_labels.append(status_lbl)
+
+
+## Reads every chef and waiter from the scene tree and updates the status labels.
+## Safe to call when no NPCs exist yet (shows "Available" for all slots).
+func refresh_status_queue() -> void:
+	var tree := get_tree()
+	if tree == null:
+		return
+
+	# ── Chefs ─────────────────────────────────────────────────────────────
+	var chefs : Array = tree.get_nodes_in_group("chefs")
+	chefs.sort_custom(func(a, b): return a.name < b.name)
+
+	for i in range(_chef_status_labels.size()):
+		var lbl    := _chef_status_labels[i]
+		var status := "Available"
+		var color  := C_ACCENT
+
+		if i < chefs.size():
+			var chef := chefs[i] as ChefFSM
+			if chef == null or not is_instance_valid(chef):
+				status = "—"
+				color  = C_MUTED
+			elif chef.is_turn_active:
+				match chef.current_role:
+					"cook":
+						status = "Cooking"
+						color  = C_WARN
+					"prep":
+						status = "Prepping"
+						color  = C_WARN
+					_:
+						status = "Busy"
+						color  = C_WARN
+			else:
+				# Between rounds — show what role they last performed
+				match chef.current_role:
+					"cook":
+						status = "Cook ✓"
+						color  = C_MUTED
+					"prep":
+						status = "Prep ✓"
+						color  = C_MUTED
+					_:
+						status = "Available"
+						color  = C_ACCENT
+		else:
+			status = "—"
+			color  = C_MUTED
+
+		lbl.text = status
+		lbl.add_theme_color_override("font_color", color)
+
+	# ── Waiters ───────────────────────────────────────────────────────────
+	var waiters : Array = tree.get_nodes_in_group("waiters")
+	waiters.sort_custom(func(a, b): return a.name < b.name)
+
+	for i in range(_waiter_status_labels.size()):
+		var lbl    := _waiter_status_labels[i]
+		var status := "Available"
+		var color  := C_ACCENT
+
+		if i < waiters.size():
+			var waiter := waiters[i] as WaiterFSM
+			if waiter == null or not is_instance_valid(waiter):
+				status = "—"
+				color  = C_MUTED
+			elif waiter.is_turn_active:
+				if waiter.assigned_plate_index > 0:
+					status = "On Plate %d" % waiter.assigned_plate_index
+					color  = C_TEXT
+				else:
+					status = "Busy"
+					color  = C_WARN
+			else:
+				# Between rounds — show last plate or available
+				if waiter.assigned_plate_index > 0:
+					status = "Plate %d ✓" % waiter.assigned_plate_index
+					color  = C_MUTED
+				else:
+					status = "Available"
+					color  = C_ACCENT
+		else:
+			status = "—"
+			color  = C_MUTED
+
+		lbl.text = status
+		lbl.add_theme_color_override("font_color", color)
 
 # ---------------------------------------------------------------------------
 # Display refresh
@@ -145,18 +359,16 @@ func _on_start_round_pressed() -> void:
 
 func _refresh_display() -> void:
 	round_label.text = "ROUND %02d" % GameConfig.current_round
-	hp_label.text    = "HP: %d / %d" % [GameConfig.player_hp, GameConfig.MAX_HP]
-	score_label.text = "SCORE: %d"   % GameConfig.score
+	hp_label.text    = "HP: %d/%d"  % [GameConfig.player_hp, GameConfig.MAX_HP]
+	score_label.text = "SCORE: %d"  % GameConfig.score
 
-	# Color HP label by urgency
 	var hp_color : Color
 	match GameConfig.player_hp:
-		3:     hp_color = C_ACCENT
-		2:     hp_color = C_WARN
-		_:     hp_color = C_DANGER
+		3:    hp_color = C_ACCENT
+		2:    hp_color = C_WARN
+		_:    hp_color = C_DANGER
 	hp_label.add_theme_color_override("font_color", hp_color)
 
-	# Disable Start if nothing is allocated
 	var any_alloc := (cook_spin.value + prep_spin.value
 		+ plate1_spin.value + plate2_spin.value + plate3_spin.value) > 0
 	start_btn.disabled = not any_alloc or RoundManager.is_round_active()
@@ -167,7 +379,7 @@ func _reset_spins() -> void:
 		spin.value = 0
 
 # ---------------------------------------------------------------------------
-# Public API — called by kitchen_scene when RoundManager signals hp_changed
+# Public API
 # ---------------------------------------------------------------------------
 
 func update_hp_display(new_hp: int) -> void:
@@ -175,7 +387,7 @@ func update_hp_display(new_hp: int) -> void:
 	_refresh_display()
 
 # ---------------------------------------------------------------------------
-# Theme
+# Theme helpers
 # ---------------------------------------------------------------------------
 
 func _apply_theme() -> void:
@@ -185,6 +397,7 @@ func _apply_theme() -> void:
 	_style_sep(title_sep)
 	_style_sep(footer_sep)
 	_style_sep(vsep1)
+	if vsep2: _style_sep(vsep2)
 
 	_style_label(round_label, C_MUTED,  10)
 	_style_label(hp_label,    C_ACCENT, 12)
@@ -234,8 +447,7 @@ func _style_sep(sep: Control) -> void:
 	var s      := StyleBoxLine.new()
 	s.color     = C_BORDER
 	s.thickness = 1
-	var key := "separator"
-	sep.add_theme_stylebox_override(key, s)
+	sep.add_theme_stylebox_override("separator", s)
 
 
 func _style_start_btn() -> void:


### PR DESCRIPTION
Replaced the old FIFO/SJF/SJCF multi-algorithm panels with the three-column layout the script expects: CHEFS (Cook/Prep spinboxes), WAITERS (Plate1/2/3 spinboxes), and a VSep2 placeholder before the NPC STATUS column that the script builds in code at runtime.

Added the missing %HPLabel and %ScoreLabel unique-name nodes to TitleHBox so _refresh_display() no longer crashes on startup. All @onready path and unique- name references in os_menu.gd now resolve correctly against the scene tree.