### PR TITLE
Add score tracking, customer recycling, waiter idle-return, and win condition

### DIFF
--- a/scripts/game_config.gd
+++ b/scripts/game_config.gd
@@ -33,6 +33,7 @@ var score         : int = 0
 
 const MAX_HP     : int = 3
 const MAX_PLATES : int = 3
+const WIN_SCORE  : int = 12
 
 func set_turn_allocations(cooks: int, preps: int, w1: int, w2: int, w3: int) -> void:
 	chef_cook_count     = cooks
@@ -54,6 +55,9 @@ func deduct_hp(amount: int = 1) -> void:
 
 func is_game_over() -> bool:
 	return player_hp <= 0
+
+func is_game_won() -> bool:
+	return score >= WIN_SCORE
 
 func add_score(amount: int = 1) -> void:
 	score += amount

--- a/scripts/kitchen_scene.gd
+++ b/scripts/kitchen_scene.gd
@@ -16,6 +16,7 @@ extends Node2D
 # ---------------------------------------------------------------------------
 
 var _game_over_shown : bool = false
+var _game_won_shown  : bool = false
 
 # ---------------------------------------------------------------------------
 # Lifecycle
@@ -25,6 +26,7 @@ func _ready() -> void:
 	# Connect RoundManager signals
 	RoundManager.hp_changed.connect(_on_hp_changed)
 	RoundManager.game_over.connect(_on_game_over)
+	RoundManager.game_won.connect(_on_game_won)
 	RoundManager.round_complete.connect(_on_round_complete)
 
 	# Start the game — one physics frame defer is inside start_game() already
@@ -51,6 +53,12 @@ func _on_game_over() -> void:
 		return
 	_game_over_shown = true
 	_show_game_over_overlay()
+
+func _on_game_won() -> void:
+	if _game_won_shown:
+		return
+	_game_won_shown = true
+	_show_win_overlay()
 
 # ---------------------------------------------------------------------------
 # Game-over overlay (black screen + "GAME OVER" text + score)
@@ -91,6 +99,46 @@ func _show_game_over_overlay() -> void:
 	canvas.add_child(score_lbl)
 
 	# Restart hint
+	var hint := Label.new()
+	hint.text = "Press F5 to restart"
+	hint.set_anchors_and_offsets_preset(Control.PRESET_CENTER)
+	hint.position      -= Vector2(200, -60)
+	hint.custom_minimum_size = Vector2(400, 30)
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	hint.add_theme_font_size_override("font_size", 16)
+	hint.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6))
+	canvas.add_child(hint)
+
+func _show_win_overlay() -> void:
+	var canvas := CanvasLayer.new()
+	canvas.layer = 100
+	add_child(canvas)
+
+	var bg := ColorRect.new()
+	bg.color = Color(0.0, 0.0, 0.0, 0.92)
+	bg.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	canvas.add_child(bg)
+
+	var title := Label.new()
+	title.text = "Winner!!!"
+	title.set_anchors_and_offsets_preset(Control.PRESET_CENTER)
+	title.position      -= Vector2(200, 60)
+	title.custom_minimum_size = Vector2(400, 80)
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", 64)
+	title.add_theme_color_override("font_color", Color.GREEN)
+	canvas.add_child(title)
+
+	var score_lbl := Label.new()
+	score_lbl.text = "Final Score: %d customers served" % GameConfig.score
+	score_lbl.set_anchors_and_offsets_preset(Control.PRESET_CENTER)
+	score_lbl.position      -= Vector2(200, -20)
+	score_lbl.custom_minimum_size = Vector2(400, 40)
+	score_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	score_lbl.add_theme_font_size_override("font_size", 24)
+	score_lbl.add_theme_color_override("font_color", Color.WHITE)
+	canvas.add_child(score_lbl)
+
 	var hint := Label.new()
 	hint.text = "Press F5 to restart"
 	hint.set_anchors_and_offsets_preset(Control.PRESET_CENTER)

--- a/scripts/os-menu-script/os_menu.gd
+++ b/scripts/os-menu-script/os_menu.gd
@@ -51,6 +51,8 @@ func _connect_signals() -> void:
 		RoundManager.hp_changed.connect(_on_hp_changed)
 	if not RoundManager.game_over.is_connected(_on_game_over):
 		RoundManager.game_over.connect(_on_game_over)
+	if not RoundManager.game_won.is_connected(_on_game_won):
+		RoundManager.game_won.connect(_on_game_won)
 
 func _on_spin_changed(_v: float) -> void:
 	_refresh_display()
@@ -64,6 +66,10 @@ func _on_hp_changed(_new_hp: int) -> void:
 	_refresh_display()
 
 func _on_game_over() -> void:
+	_refresh_display()
+	start_btn.disabled = true
+
+func _on_game_won() -> void:
 	_refresh_display()
 	start_btn.disabled = true
 
@@ -82,7 +88,7 @@ func _on_start_round_pressed() -> void:
 	_refresh_display()
 
 	# Only re-enable if the game is still running.
-	if not GameConfig.is_game_over():
+	if not GameConfig.is_game_over() and not GameConfig.is_game_won():
 		start_btn.disabled = false
 
 func _dispatch_waiters_from_spins() -> void:
@@ -112,6 +118,10 @@ func _dispatch_waiters_from_spins() -> void:
 			else:
 				waiter.execute_turn(role)
 			role_idx += 1
+		else:
+			# Spin decreased — send active waiter back to idle position.
+			if waiter.is_turn_active:
+				waiter.return_to_idle_position()
 
 func _build_status_queue_panel() -> void:
 	if body_row == null:
@@ -247,7 +257,7 @@ func _refresh_display() -> void:
 
 	var any_alloc := (cook_spin.value + prep_spin.value
 		+ plate1_spin.value + plate2_spin.value + plate3_spin.value) > 0
-	start_btn.disabled = not any_alloc or RoundManager.is_round_active() or GameConfig.is_game_over()
+	start_btn.disabled = not any_alloc or RoundManager.is_round_active() or GameConfig.is_game_over() or GameConfig.is_game_won()
 
 func _reset_spins() -> void:
 	for spin in [cook_spin, prep_spin, plate1_spin, plate2_spin, plate3_spin]:

--- a/scripts/round_manager.gd
+++ b/scripts/round_manager.gd
@@ -214,7 +214,11 @@ func _register_existing_customers() -> void:
 			c.walk_to_seat()
 
 func _on_customer_fed(customer: CustomerFSM) -> void:
+	GameConfig.add_score(1)
+	hp_changed.emit(GameConfig.player_hp)
 	print("RoundManager: '%s' fed — score=%d" % [customer.name, GameConfig.score])
+	if GameConfig.is_game_won():
+		_trigger_game_won()
 
 func _on_customer_timed_out(customer: CustomerFSM) -> void:
 	print("RoundManager: '%s' timed out — HP=%d" % [customer.name, GameConfig.player_hp])
@@ -225,6 +229,10 @@ func _trigger_game_over() -> void:
 			node.play()
 	print("RoundManager: GAME OVER — score=%d" % GameConfig.score)
 	game_over.emit()
+
+func _trigger_game_won() -> void:
+	print("RoundManager: GAME WON — score=%d" % GameConfig.score)
+	game_won.emit()
 
 func get_current_round() -> int:  return GameConfig.current_round
 func get_player_hp()     -> int:  return GameConfig.player_hp

--- a/scripts/states/customer_fsm.gd
+++ b/scripts/states/customer_fsm.gd
@@ -74,7 +74,12 @@ func _on_state_enter(state: int) -> void:
 			customer_fed.emit(self)
 			await get_tree().create_timer(1.0).timeout
 			if _state_gen != gen: return
-			change_state(State.LEAVING)
+			# Reset and move to a new plate for the next service cycle.
+			_assign_random_patience()
+			_update_label()
+			_has_been_fed = false
+			_pick_new_plate()
+			change_state(State.WALK_TO_SEAT)
 
 		State.LEAVING:
 			play_anim("walk")
@@ -136,6 +141,16 @@ func is_seated() -> bool:
 
 func is_fed() -> bool:
 	return _has_been_fed
+
+func _pick_new_plate() -> void:
+	var groups := ["plate1", "plate2", "plate3"]
+	groups.shuffle()
+	for group in groups:
+		var plate := get_tree().get_first_node_in_group(group) as Node2D
+		if plate != null and plate != assigned_plate:
+			assigned_plate = plate
+			return
+	# Fallback: stay at same plate if no other is available.
 
 func _assign_random_patience() -> void:
 	var roll := randi() % 3

--- a/scripts/states/waiter_fsm.gd
+++ b/scripts/states/waiter_fsm.gd
@@ -84,5 +84,12 @@ func redirect_to(role: String) -> void:
 	target_plate       = plate
 	change_state(State.WALK_TO_PLATE)
 
+func return_to_idle_position() -> void:
+	_is_moving         = false
+	_arrival_state     = -1
+	_finish_on_arrival = false
+	target_plate       = null
+	change_state(State.RETURN_TO_IDLE)
+
 func is_available() -> bool:
 	return current_state == State.IDLE and not is_turn_active


### PR DESCRIPTION
## Summary
- Score tracking fixed — _on_customer_fed now calls GameConfig.add_score(1); score was tracked but never incremented
- Customer recycling — after being fed, customers reset patience (random tier) and walk to a new plate instead of queue_free()-ing
- Win condition — 12 serviced customers shows a green "Winner!!!" overlay and locks the start button
- Waiter idle-return — added return_to_idle_position(); _dispatch_waiters_from_spins calls it when a spin is decreased and a waiter loses its assignment

## Files changed
- game_config.gd: WIN_SCORE = 12, is_game_won()
- round_manager.gd: increment score on fed, _trigger_game_won(), emit game_won signal
- customer_fsm.gd: FED → reset patience + _pick_new_plate() → WALK_TO_SEAT (not LEAVING)
- waiter_fsm.gd: return_to_idle_position() method
- os_menu.gd: connect game_won, gate start button, dispatch idle-return for de-allocated waiters
- kitchen_scene.gd: _on_game_won() + _show_win_overlay() (green font)

## Notes
- Customers timed out by patience still despawn via LEAVING/queue_free — only fed customers recycle
- _pick_new_plate() always picks a different plate; falls back to same if no alternative exists
- game_won signal already existed on RoundManagerNode but was never emitted — now fully wired