### PR TITLE
Fix broken score chain: wire burger_delivered and add round-12 win

### DIFF
--- a/scripts/round_manager.gd
+++ b/scripts/round_manager.gd
@@ -35,6 +35,7 @@ func start_game() -> void:
 
 	_spawn_customer_batch()
 	_register_existing_customers()
+	_register_waiters()
 	print("RoundManager: game started")
 
 func execute_round(
@@ -81,6 +82,9 @@ func execute_round(
 	_round_active = false
 	round_complete.emit(round_num)
 	print("RoundManager: === Round %d complete ===" % round_num)
+
+	if round_num >= 12 and not GameConfig.is_game_won():
+		_trigger_game_won()
 
 func _execute_npc_turns(
 	cook_count : int,
@@ -212,6 +216,22 @@ func _register_existing_customers() -> void:
 		if c.assigned_plate == null:
 			c.assigned_plate = GameConfig.find_least_occupied_plate()
 			c.walk_to_seat()
+
+func _register_waiters() -> void:
+	for node in get_tree().get_nodes_in_group(GROUP_WAITERS):
+		if not (node is WaiterFSM):
+			continue
+		var w := node as WaiterFSM
+		if not w.burger_delivered.is_connected(_on_burger_delivered):
+			w.burger_delivered.connect(_on_burger_delivered)
+
+func _on_burger_delivered(_waiter: WaiterFSM, plate: Node2D) -> void:
+	for node in get_tree().get_nodes_in_group(GROUP_CUSTOMERS):
+		if node is CustomerFSM:
+			var c := node as CustomerFSM
+			if c.assigned_plate == plate:
+				c.receive_meal()
+				return
 
 func _on_customer_fed(customer: CustomerFSM) -> void:
 	GameConfig.add_score(1)


### PR DESCRIPTION
## Summary
- Root cause: WaiterFSM.burger_delivered was emitted but never connected,
  so customers never received meals and add_score() was never reached.
- Fix: _register_waiters() in RoundManager connects each waiter's
  burger_delivered signal to _on_burger_delivered(), which finds the
  customer at the delivered plate and calls receive_meal().
- Also added round-12 survival win condition.

## Test plan
- [ ] Complete a full cook→prep→waiter delivery and verify score increments
- [ ] Reach score 12 — verify "Winner!!!" overlay
- [ ] Survive to round 12 with score < 12 — verify win overlay still fires
- [ ] HP → 0 — verify "GAME OVER" overlay still works